### PR TITLE
Add support for public api parameters

### DIFF
--- a/bitflyer/public.py
+++ b/bitflyer/public.py
@@ -1,5 +1,6 @@
 import requests
 import simplejson as json
+from urllib.parse import urlencode
 
 """
 document: https://lightning.bitflyer.jp/docs
@@ -17,26 +18,29 @@ class Public(object):
         pass
 
 
-    def public_api(self,url):
+    def public_api(self,url,**kwargs):
         ''' template function of public api'''
         try :
             url in api_urls
-            return json.loads(requests.get(base_url + api_urls.get(url)).text)
+            api_url = base_url + api_urls.get(url)
+            if kwargs:
+                api_url += '?' + urlencode(kwargs)
+            return json.loads(requests.get(api_url).text)
         except Exception as e:
             print(e)
     
-    def getticker(self):
+    def getticker(self,**kwargs):
         '''Ticker を取得'''
-        return self.public_api('getticker') 
+        return self.public_api('getticker',**kwargs)
     
-    def getboard(self):
+    def getboard(self,**kwargs):
         ''' 板情報を取得 '''
-        return self.public_api('getboard') 
+        return self.public_api('getboard',**kwargs)
     
-    def getexecutions(self):
+    def getexecutions(self,**kwargs):
         ''' 約定の一覧を取得 '''
-        return self.public_api('getexecutions') 
+        return self.public_api('getexecutions',**kwargs)
 
-    def gethealth(self):
+    def gethealth(self,**kwargs):
         '''get exchange health'''
-        return self.public_api('gethealth') 
+        return self.public_api('gethealth',**kwargs)

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -22,6 +22,8 @@ def test_getticker():
     ok_(isinstance(m1.getticker().get('volume'), float))
     ok_(isinstance(m1.getticker().get('best_bid_size'), float))
     ok_(isinstance(m1.getticker().get('best_bid'),float))
+    ok_(m1.getticker().get('product_code'),'BTC_JPY')
+    ok_(m1.getticker(product_code='ETH_JPY').get('product_code'),'ETH_JPY')
 def test_getexecutions():
     m1 = Public()
     ok_(isinstance(m1.getexecutions(), list))
@@ -32,6 +34,8 @@ def test_getexecutions():
     ok_(isinstance(m1.getexecutions()[0].get('sell_child_order_acceptance_id'), str))
     ok_(isinstance(m1.getexecutions()[0].get('id'), int))
     ok_(isinstance(m1.getexecutions()[0].get('buy_child_order_acceptance_id'), str))
+    ok_(isinstance(m1.getexecutions(product_code='ETH_JPY'), list))
+    ok_(len(m1.getexecutions(count=1)), 1)
 def test_getboard():
     m1 = Public()
     ok_(isinstance(m1.getboard(),dict))
@@ -40,7 +44,9 @@ def test_getboard():
     ok_(isinstance(m1.getboard().get('bids')[0].get('price'),float))
     ok_(isinstance(m1.getboard().get('asks')[0].get('size'),float))
     ok_(isinstance(m1.getboard().get('asks')[0].get('price'),float))
+    ok_(isinstance(m1.getboard(product_code='ETH_JPY'), dict))
 def test_gethealth():
     m1 = Public()
     ok_(isinstance(m1.gethealth(), dict))
     ok_(isinstance(m1.gethealth().get('status'), str))
+    ok_(isinstance(m1.gethealth(product_code='ETH_JPY'), dict))


### PR DESCRIPTION
I wanted to know the price of `ETH` using this library.
However, Public APIs couldn't send arguments. For example, `product_code`.
This change allows the Public APIs to receive parameters.

I would be grateful if you could incorporate my changes into your repository.

Thank you for creating a great library.